### PR TITLE
ci: only run tests on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: tests
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
specifying both push and pull_request makes tests run twice on pull requests.